### PR TITLE
Revert remote wallet version to latest stable release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,9 +5,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 derivation-path = "0.2.0"
 ed25519-bip32 = { path = "ed25519-bip32", version = "=0.0.1" }
 qstring = "0.7.2"
-solana-sdk = "1.14.17"
+solana-sdk = "=1.14.17"
 spacemesh-derivation-path = { path = "derivation-path", version = "=0.0.1" }
 spacemesh-remote-wallet = { path = "remote-wallet", version = "=0.0.1" }
 thiserror = "1.0.40"

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -67,7 +67,6 @@ mod commands {
     pub const GET_APP_CONFIGURATION: u8 = 0x04;
     pub const GET_PUBKEY: u8 = 0x05;
     pub const SIGN_MESSAGE: u8 = 0x06;
-    pub const SIGN_OFFCHAIN_MESSAGE: u8 = 0x07;
 }
 
 enum ConfigurationVersion {
@@ -279,7 +278,7 @@ impl LedgerWallet {
                 self.pretty_path
             );
             let result = self.read()?;
-            println!("{CHECK_MARK}Approved");
+            println!("{}Approved", CHECK_MARK);
             Ok(result)
         } else {
             self.read()
@@ -428,13 +427,6 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
         derivation_path: &DerivationPath,
         data: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
-        // If the first byte of the data is 0xff then it is an off-chain message
-        // because it starts with the Domain Specifier b"\xffsolana offchain".
-        // On-chain messages, in contrast, start with either 0x80 (MESSAGE_VERSION_PREFIX)
-        // or the number of signatures (0x00 - 0x13).
-        if !data.is_empty() && data[0] == 0xff {
-            return self.sign_offchain_message(derivation_path, data);
-        }
         let mut payload = if self.outdated_app() {
             extend_and_serialize(derivation_path)
         } else {
@@ -503,55 +495,10 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
             chunks.last_mut().unwrap().0 &= !P2_MORE;
 
             for (p2, payload) in chunks {
-                result = self.send_apdu(
-                    if self.outdated_app() {
-                        commands::DEPRECATED_SIGN_MESSAGE
-                    } else {
-                        commands::SIGN_MESSAGE
-                    },
-                    p1,
-                    p2,
-                    &payload,
-                )?;
+                result = self.send_apdu(commands::SIGN_MESSAGE, p1, p2, &payload)?;
             }
         }
 
-        if result.len() != 64 {
-            return Err(RemoteWalletError::Protocol(
-                "Signature packet size mismatch",
-            ));
-        }
-        Ok(Signature::new(&result))
-    }
-
-    fn sign_offchain_message(
-        &self,
-        derivation_path: &DerivationPath,
-        message: &[u8],
-    ) -> Result<Signature, RemoteWalletError> {
-        if message.len()
-            > solana_sdk::offchain_message::v0::OffchainMessage::MAX_LEN_LEDGER
-                + solana_sdk::offchain_message::v0::OffchainMessage::HEADER_LEN
-        {
-            return Err(RemoteWalletError::InvalidInput(
-                "Off-chain message to sign is too long".to_string(),
-            ));
-        }
-
-        let mut data = extend_and_serialize_multiple(&[derivation_path]);
-        data.extend_from_slice(message);
-
-        let p1 = P1_CONFIRM;
-        let mut p2 = 0;
-        let mut payload = data.as_slice();
-        while payload.len() > MAX_CHUNK_SIZE {
-            let chunk = &payload[..MAX_CHUNK_SIZE];
-            self.send_apdu(commands::SIGN_OFFCHAIN_MESSAGE, p1, p2 | P2_MORE, chunk)?;
-            payload = &payload[MAX_CHUNK_SIZE..];
-            p2 |= P2_EXTEND;
-        }
-
-        let result = self.send_apdu(commands::SIGN_OFFCHAIN_MESSAGE, p1, p2, payload)?;
         if result.len() != 64 {
             return Err(RemoteWalletError::Protocol(
                 "Signature packet size mismatch",
@@ -631,8 +578,9 @@ pub fn get_ledger_from_info(
 
     let wallet_host_device_path = if host_device_paths.len() > 1 {
         let selection = Select::with_theme(&ColorfulTheme::default())
-            .with_prompt(format!(
-                "Multiple hardware wallets found. Please select a device for {keypair_name:?}"
+            .with_prompt(&format!(
+                "Multiple hardware wallets found. Please select a device for {:?}",
+                keypair_name
             ))
             .default(0)
             .items(&items[..])

--- a/remote-wallet/src/ledger_error.rs
+++ b/remote-wallet/src/ledger_error.rs
@@ -71,15 +71,6 @@ pub enum LedgerError {
     #[error("Ledger received invalid Solana message")]
     SolanaInvalidMessage = 0x6a80,
 
-    #[error("Ledger received message with invalid header")]
-    SolanaInvalidMessageHeader = 0x6a81,
-
-    #[error("Ledger received message in invalid format")]
-    SolanaInvalidMessageFormat = 0x6a82,
-
-    #[error("Ledger received message with invalid size")]
-    SolanaInvalidMessageSize = 0x6a83,
-
     #[error("Solana summary finalization failed on Ledger device")]
     SolanaSummaryFinalizeFailed = 0x6f00,
 

--- a/remote-wallet/src/locator.rs
+++ b/remote-wallet/src/locator.rs
@@ -63,7 +63,7 @@ impl AsRef<str> for Manufacturer {
 impl std::fmt::Display for Manufacturer {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let s: &str = self.as_ref();
-        write!(f, "{s}")
+        write!(f, "{}", s)
     }
 }
 
@@ -108,7 +108,7 @@ impl std::fmt::Display for Locator {
             .unwrap();
 
         let uri = builder.build().unwrap();
-        write!(f, "{uri}")
+        write!(f, "{}", uri)
     }
 }
 
@@ -344,11 +344,11 @@ mod tests {
     fn test_locator_new_from_path() {
         let manufacturer = Manufacturer::Ledger;
         let pubkey = Pubkey::new_unique();
-        let path = format!("usb://ledger/{pubkey}?key=0/0");
+        let path = format!("usb://ledger/{}?key=0/0", pubkey);
         Locator::new_from_path(path).unwrap();
 
         // usb://ledger/{PUBKEY}?key=0'/0'
-        let path = format!("usb://ledger/{pubkey}?key=0'/0'");
+        let path = format!("usb://ledger/{}?key=0'/0'", pubkey);
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),
@@ -356,7 +356,7 @@ mod tests {
         assert_eq!(Locator::new_from_path(path), Ok(expect));
 
         // usb://ledger/{PUBKEY}
-        let path = format!("usb://ledger/{pubkey}");
+        let path = format!("usb://ledger/{}", pubkey);
         let expect = Locator {
             manufacturer,
             pubkey: Some(pubkey),

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -228,22 +228,11 @@ pub trait RemoteWallet<T> {
         unimplemented!();
     }
 
-    /// Sign transaction data with wallet managing pubkey at derivation path
-    /// `m/44'/501'/<account>'/<change>'`.
+    /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
     fn sign_message(
         &self,
         derivation_path: &DerivationPath,
         data: &[u8],
-    ) -> Result<Signature, RemoteWalletError> {
-        unimplemented!();
-    }
-
-    /// Sign off-chain message with wallet managing pubkey at derivation path
-    /// `m/44'/501'/<account>'/<change>'`.
-    fn sign_offchain_message(
-        &self,
-        derivation_path: &DerivationPath,
-        message: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
         unimplemented!();
     }
@@ -413,7 +402,7 @@ mod tests {
         };
         assert_eq!(
             remote_wallet_info.get_pretty_path(),
-            format!("usb://ledger/{pubkey_str}")
+            format!("usb://ledger/{}", pubkey_str)
         );
     }
 }

--- a/remote-wallet/src/remote_wallet.rs
+++ b/remote-wallet/src/remote_wallet.rs
@@ -228,7 +228,7 @@ pub trait RemoteWallet<T> {
         unimplemented!();
     }
 
-    /// Sign transaction data with wallet managing pubkey at derivation path m/44'/501'/<account>'/<change>'.
+    /// Sign transaction data with wallet managing pubkey at derivation path m/44'/540'/<account>'/<change>'.
     fn sign_message(
         &self,
         derivation_path: &DerivationPath,


### PR DESCRIPTION
This rolls back the forked remote-wallet libraries to v1.14.7 to match the pinned solana-sdk dependency. Compare

https://github.com/solana-labs/solana/commits/v1.14.17/remote-wallet/src/ledger.rs
https://github.com/solana-labs/solana/commits/master/remote-wallet/src/ledger.rs